### PR TITLE
Python < 2.7 compatibilty

### DIFF
--- a/pyusps/address_information.py
+++ b/pyusps/address_information.py
@@ -2,7 +2,10 @@ import urllib2
 import urllib
 
 from lxml import etree
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 api_url = 'http://production.shippingapis.com/ShippingAPI.dll'
 address_max = 5

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=[
         'setuptools>=0.6c11',
         'lxml>=2.3.3',
+        'ordereddict==1.1',
         ],
     extras_require=EXTRAS_REQUIRES,
     )


### PR DESCRIPTION
Right now the code uses OrderedDict which was added on Python 2.7. I modified so it uses ordereddict.OrderedDict if the native OrderedDict is not available.
